### PR TITLE
Exclude escaping quotes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ if [ -n "$NGROK_HEADER" ]; then
 fi
 
 if [ -n "$NGROK_USERNAME" ] && [ -n "$NGROK_PASSWORD" ] && [ -n "$NGROK_AUTH" ]; then
-  ARGS="$ARGS -auth=\"$NGROK_USERNAME:$NGROK_PASSWORD\" "
+  ARGS="$ARGS -auth=$NGROK_USERNAME:$NGROK_PASSWORD "
 elif [ -n "$NGROK_USERNAME" ] || [ -n "$NGROK_PASSWORD" ]; then
   if [ -z "$NGROK_AUTH" ]; then
     echo "You must specify a username, password, and Ngrok authentication token to use the custom HTTP authentication."


### PR DESCRIPTION
I don't know the exact rationale for these quotes. May be required for special characters but they break passing `username:password` to ngrok.

Fixes #10 