### PR TITLE
#36 Persist auth token to ~/.ngrok2/ngrok.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x \
  && adduser -h /home/ngrok -D -u 6737 ngrok
 
 # Add config script.
-COPY ngrok.yml /home/ngrok/.ngrok2/
+COPY --chown=ngrok ngrok.yml /home/ngrok/.ngrok2/
 COPY entrypoint.sh /
 
 USER ngrok

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,7 +12,7 @@ RUN set -x \
  && adduser -h /home/ngrok -D -u 6737 ngrok
 
 # Add config script.
-COPY ngrok.yml /home/ngrok/.ngrok2/
+COPY --chown=ngrok ngrok.yml /home/ngrok/.ngrok2/
 COPY entrypoint.sh /
 
 RUN [ "cross-build-end" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ fi
 
 # Set the authorization token.
 if [ -n "$NGROK_AUTH" ]; then
-  ARGS="$ARGS -authtoken=$NGROK_AUTH "
+  echo "authtoken: $NGROK_AUTH" >> ~/.ngrok2/ngrok.yml
 fi
 
 # Set the subdomain or hostname, depending on which is set


### PR DESCRIPTION
https://github.com/wernight/docker-ngrok/issues/36:
Persist auth token to `~/.ngrok2/ngrok.yml` instead of appending it to command line args