### PR TITLE
Add architecture detection to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ RUN set -x \
  && apk add --no-cache curl \
  && APKARCH="$(apk --print-arch)" \
  && case "$APKARCH" in \
-      armhf)  NGROKARCH="arm" ;; \ 
-      armv7)  NGROKARCH="arm" ;; \
-      x86)    NGROKARCH="386" ;; \
-      x86_64) NGROKARCH="amd64" ;; \
+      armhf)   NGROKARCH="arm" ;; \ 
+      armv7)   NGROKARCH="arm" ;; \
+      armel)   NGROKARCH="arm" ;; \
+      x86)     NGROKARCH="386" ;; \
+      x86_64)  NGROKARCH="amd64" ;; \
     esac \
  && curl -Lo /ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-$NGROKARCH.zip \
  && unzip -o /ngrok.zip -d /bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,14 @@ RUN set -x && \
 RUN set -x \
     # Install ngrok (latest official stable from https://ngrok.com/download).
  && apk add --no-cache curl \
- && curl -Lo /ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip \
+ && APKARCH="$(apk --print-arch)" \
+ && case "$APKARCH" in \
+      armhf)  NGROKARCH="arm" ;; \ 
+      armv7)  NGROKARCH="arm" ;; \
+      x86)    NGROKARCH="386" ;; \
+      x86_64) NGROKARCH="amd64" ;; \
+    esac \
+ && curl -Lo /ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-$NGROKARCH.zip \
  && unzip -o /ngrok.zip -d /bin \
  && rm -f /ngrok.zip \
     # Create non-root user.


### PR DESCRIPTION
I tried to build this image on a Pi and discovered it was hard-coded to fetch an amd64 zip of ngrok. This PR enhances the main Dockerfile so it downloads the correct file from the ngrok repository, depending on the architecture detected in the image as it's being built.

Notes:
* This will conflict with #45, but it will be trivial to merge them manually.
* I've ignored the `aarch64` architecture - the download url is different for this arch and I have no way of testing what consequently would be more complicated code. I don't believe it's widely used, currently.
* I've tested the change on a Pi 3 (reporting `armv7`) and an Ubuntu vm on `amd64`.