### PR TITLE
Add a timeout option to kill the service after a given amount of time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.9
 MAINTAINER Werner Beroux <werner@beroux.com>
 
+RUN apk add --update coreutils && rm -rf /var/cache/apk/*
 RUN set -x && \
     apk add --no-cache -t .deps ca-certificates && \
     # Install glibc on Alpine (required by docker-compose) from

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Additionally, you can specify one of several environment variable (via `-e`) to 
   * `NGROK_REGION` - Location of the ngrok tunnel server; can be `us` (United States, default), `eu` (Europe), `ap` (Asia/Pacific) or `au` (Australia)
   * `NGROK_LOOK_DOMAIN` - This is the domain name referred to by ngrok. (default: localhost).
   * `NGROK_BINDTLS` - Toggle tunneling only HTTP or HTTPS traffic. When `true`, Ngrok only opens the HTTPS endpoint. When `false`, Ngrok only opens the HTTP endpoint
+  * `NGROK_TIMEOUT` - Kill the ngrok process after the timeout value (typically `24h`).  Quite handy to use with the `restart: on-failure` option in your docker-compose.yml
 
 #### Full example
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,10 @@ fi
 
 ARGS="ngrok"
 
+if [ -n "$NGROK_TIMEOUT" ]; then
+  ARGS="timeout $NGROK_TIMEOUT $ARGS"
+fi
+
 # Set the protocol.
 if [ "$NGROK_PROTOCOL" = "TCP" ]; then
   ARGS="$ARGS tcp"


### PR DESCRIPTION
Requires coreutils for the "timeout" command, but it was so easy to do, it seemed worth the added weight.