### PR TITLE
Run entrypoint script with ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN ngrok --version
 
 EXPOSE 4040
 
-CMD ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Fixes https://github.com/wernight/docker-ngrok/issues/65.

As stated in the [official doc](https://docs.docker.com/engine/reference/builder/#cmd), the main purpose of the CMD instruction is to provide a default. If this default is overridden when running `docker run`, the default will not run.
A better instruction to run the entrypoint script, therefore, is ENTRYPOINT, which will always run unless it's explicitly overridden with the `--entrypoint` flag.