### PR TITLE
Adding ability to specify config file in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ ARGS="ngrok"
 # Use config file instead
 if [ -n "$NGROK_CONFIG" ]; then
 
-  ARGS="$ARGS start -config ${NGROK_CONFIG} -all"
+  ARGS="$ARGS start --all -config=${NGROK_CONFIG}"
   exec $ARGS
 
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,81 +18,89 @@ fi
 
 ARGS="ngrok"
 
-# Set the protocol.
-if [ "$NGROK_PROTOCOL" = "TCP" ]; then
-  ARGS="$ARGS tcp"
-elif [ "$NGROK_PROTOCOL" = "TLS" ]; then
-  ARGS="$ARGS tls"
-  NGROK_PORT="${NGROK_PORT:-443}"
+# Use config file instead
+if [ -n "$NGROK_CONFIG" ]; then
+
+  ARGS="$ARGS -config /home/ngrok/.ngrok2/ngrok.yml -all"
+  exec $ARGS
+
 else
-  ARGS="$ARGS http"
-  NGROK_PORT="${NGROK_PORT:-80}"
-fi
+  # Set the protocol.
+  if [ "$NGROK_PROTOCOL" = "TCP" ]; then
+    ARGS="$ARGS tcp"
+  elif [ "$NGROK_PROTOCOL" = "TLS" ]; then
+    ARGS="$ARGS tls"
+    NGROK_PORT="${NGROK_PORT:-443}"
+  else
+    ARGS="$ARGS http"
+    NGROK_PORT="${NGROK_PORT:-80}"
+  fi
 
-# Set the TLS binding flag
-if [ -n "$NGROK_BINDTLS" ]; then
-  ARGS="$ARGS -bind-tls=$NGROK_BINDTLS "
-fi
+  # Set the TLS binding flag
+  if [ -n "$NGROK_BINDTLS" ]; then
+    ARGS="$ARGS -bind-tls=$NGROK_BINDTLS "
+  fi
 
-# Set the authorization token.
-if [ -n "$NGROK_AUTH" ]; then
-  echo -e "\nauthtoken: $NGROK_AUTH" >> $HOME/.ngrok2/ngrok.yml
-fi
+  # Set the authorization token.
+  if [ -n "$NGROK_AUTH" ]; then
+    echo -e "\nauthtoken: $NGROK_AUTH" >> $HOME/.ngrok2/ngrok.yml
+  fi
 
-# Set the subdomain or hostname, depending on which is set
-if [ -n "$NGROK_HOSTNAME" ] && [ -n "$NGROK_AUTH" ]; then
-  ARGS="$ARGS -hostname=$NGROK_HOSTNAME "
-elif [ -n "$NGROK_SUBDOMAIN" ] && [ -n "$NGROK_AUTH" ]; then
-  ARGS="$ARGS -subdomain=$NGROK_SUBDOMAIN "
-elif [ -n "$NGROK_HOSTNAME" ] || [ -n "$NGROK_SUBDOMAIN" ]; then
-  if [ -z "$NGROK_AUTH" ]; then
-    echo "You must specify an authentication token after registering at https://ngrok.com to use custom domains."
+  # Set the subdomain or hostname, depending on which is set
+  if [ -n "$NGROK_HOSTNAME" ] && [ -n "$NGROK_AUTH" ]; then
+    ARGS="$ARGS -hostname=$NGROK_HOSTNAME "
+  elif [ -n "$NGROK_SUBDOMAIN" ] && [ -n "$NGROK_AUTH" ]; then
+    ARGS="$ARGS -subdomain=$NGROK_SUBDOMAIN "
+  elif [ -n "$NGROK_HOSTNAME" ] || [ -n "$NGROK_SUBDOMAIN" ]; then
+    if [ -z "$NGROK_AUTH" ]; then
+      echo "You must specify an authentication token after registering at https://ngrok.com to use custom domains."
+      exit 1
+    fi
+  fi
+
+  # Set the remote-addr if specified
+  if [ -n "$NGROK_REMOTE_ADDR" ]; then
+    if [ -z "$NGROK_AUTH" ]; then
+      echo "You must specify an authentication token after registering at https://ngrok.com to use reserved ip addresses."
+      exit 1
+    fi
+    ARGS="$ARGS -remote-addr=$NGROK_REMOTE_ADDR "
+  fi
+
+  # Set a custom region
+  if [ -n "$NGROK_REGION" ]; then
+    ARGS="$ARGS -region=$NGROK_REGION "
+  fi
+
+  if [ -n "$NGROK_HEADER" ]; then
+    ARGS="$ARGS -host-header=$NGROK_HEADER "
+  fi
+
+  if [ -n "$NGROK_USERNAME" ] && [ -n "$NGROK_PASSWORD" ] && [ -n "$NGROK_AUTH" ]; then
+    ARGS="$ARGS -auth=$NGROK_USERNAME:$NGROK_PASSWORD "
+  elif [ -n "$NGROK_USERNAME" ] || [ -n "$NGROK_PASSWORD" ]; then
+    if [ -z "$NGROK_AUTH" ]; then
+      echo "You must specify a username, password, and Ngrok authentication token to use the custom HTTP authentication."
+      echo "Sign up for an authentication token at https://ngrok.com"
+      exit 1
+    fi
+  fi
+
+  if [ -n "$NGROK_DEBUG" ]; then
+      ARGS="$ARGS -log stdout"
+  fi
+
+  # Set the port.
+  if [ -z "$NGROK_PORT" ]; then
+    echo "You must specify a NGROK_PORT to expose."
     exit 1
   fi
-fi
 
-# Set the remote-addr if specified
-if [ -n "$NGROK_REMOTE_ADDR" ]; then
-  if [ -z "$NGROK_AUTH" ]; then
-    echo "You must specify an authentication token after registering at https://ngrok.com to use reserved ip addresses."
-    exit 1
+  if [ -n "$NGROK_LOOK_DOMAIN" ]; then
+    ARGS="$ARGS `echo $NGROK_LOOK_DOMAIN:$NGROK_PORT | sed 's|^tcp://||'`"
+  else
+    ARGS="$ARGS `echo $NGROK_PORT | sed 's|^tcp://||'`"
   fi
-  ARGS="$ARGS -remote-addr=$NGROK_REMOTE_ADDR "
-fi
 
-# Set a custom region
-if [ -n "$NGROK_REGION" ]; then
-  ARGS="$ARGS -region=$NGROK_REGION "
+  exec $ARGS
 fi
-
-if [ -n "$NGROK_HEADER" ]; then
-  ARGS="$ARGS -host-header=$NGROK_HEADER "
-fi
-
-if [ -n "$NGROK_USERNAME" ] && [ -n "$NGROK_PASSWORD" ] && [ -n "$NGROK_AUTH" ]; then
-  ARGS="$ARGS -auth=$NGROK_USERNAME:$NGROK_PASSWORD "
-elif [ -n "$NGROK_USERNAME" ] || [ -n "$NGROK_PASSWORD" ]; then
-  if [ -z "$NGROK_AUTH" ]; then
-    echo "You must specify a username, password, and Ngrok authentication token to use the custom HTTP authentication."
-    echo "Sign up for an authentication token at https://ngrok.com"
-    exit 1
-  fi
-fi
-
-if [ -n "$NGROK_DEBUG" ]; then
-    ARGS="$ARGS -log stdout"
-fi
-
-# Set the port.
-if [ -z "$NGROK_PORT" ]; then
-  echo "You must specify a NGROK_PORT to expose."
-  exit 1
-fi
-
-if [ -n "$NGROK_LOOK_DOMAIN" ]; then
-  ARGS="$ARGS `echo $NGROK_LOOK_DOMAIN:$NGROK_PORT | sed 's|^tcp://||'`"
-else
-  ARGS="$ARGS `echo $NGROK_PORT | sed 's|^tcp://||'`"
-fi
-
-exec $ARGS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ ARGS="ngrok"
 # Use config file instead
 if [ -n "$NGROK_CONFIG" ]; then
 
-  ARGS="$ARGS -config /home/ngrok/.ngrok2/ngrok.yml -all"
+  ARGS="$ARGS -config ${NGROK_CONFIG} -all"
   exec $ARGS
 
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ ARGS="ngrok"
 # Use config file instead
 if [ -n "$NGROK_CONFIG" ]; then
 
-  ARGS="$ARGS -config ${NGROK_CONFIG} -all"
+  ARGS="$ARGS start -config ${NGROK_CONFIG} -all"
   exec $ARGS
 
 else


### PR DESCRIPTION
This change will start all tunnels defined in config file passed as NGROK_CONFIG, otherwise will start container as normal. If NGROK_CONFIG is specified all other configuration variables are ignored and it will only read from the .yml passed in