### PR TITLE
Updates for v3 of NGrok

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,11 @@ RUN set -x \
       x86)     NGROKARCH="386" ;; \
       x86_64)  NGROKARCH="amd64" ;; \
     esac \
- && curl -Lo /ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-$NGROKARCH.zip \
- && unzip -o /ngrok.zip -d /bin \
- && rm -f /ngrok.zip \
+ && curl -Lo /ngrok.tgz https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-$NGROKARCH.tgz \
+ && tar -xzf /ngrok.tgz \
+ && mv /ngrok /bin \
+ && chmod 755 /bin/ngrok \
+ && rm -f /ngrok.tgz \
     # Create non-root user.
  && adduser -h /home/ngrok -D -u 6737 ngrok
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You simply have to link the Ngrok container to the application under the `app` o
 
 Additionally, you can specify one of several environment variable (via `-e`) to configure your Ngrok tunnel:
 
-  * `NGROK_AUTH` - Authentication key for your Ngrok account. This is needed for custom subdomains, custom domains, and HTTP authentication.
+  * `NGROK_AUTHTOKEN` - Authentication Token for your Ngrok account. This is needed for custom subdomains, custom domains, and HTTP authentication.
   * `NGROK_SUBDOMAIN` - Name of the custom subdomain to use for your tunnel. You must also provide the authentication token.
   * `NGROK_HOSTNAME` - Paying Ngrok customers can specify a custom domain. Only one subdomain or domain can be specified, with the domain taking priority.
   * `NGROK_REMOTE_ADDR` - Name of the reserved TCP address to use for a TCP tunnel. You must also provide the authentication token.

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,1 +1,3 @@
 web_addr: 0.0.0.0:4040
+version: "2"
+region: us


### PR DESCRIPTION
The v2 version in the Dockerfile is deprecated and gets rejected now, unfortunately.  In following the original article, I managed to update to use v3 for my own writeup.  Inviting you to take in this change to swap to the new binary (zip to tgz, new URL, uses AUTHTOKEN instead of AUTH for env var, new config yaml syntax).